### PR TITLE
Fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ profile:
 	-f profile-dotemacs
 
 install: upgrade
-	cd git/cedet && make 2>&1 | tee -a ../../etc/log
 	cd git/org-mode && make compile 2>&1 | tee -a ../../etc/log
 	cd $(BASEDIR) && mkdir -p personal
 	yes n | cp -i etc/init-template.el personal/personal-init.el

--- a/packages.el
+++ b/packages.el
@@ -35,6 +35,7 @@
     hideshowvis
     j-mode
     jedi
+    ivy-hydra
     lispy
     magit
     make-it-so


### PR DESCRIPTION
CEDET was removed a while ago:
https://github.com/abo-abo/oremacs/commit/3bbad1efb9fb9a02458e39e54f034fc873e584be
but the Makefile entry was left behind.

Also, added `ivy-hydra` to packages.el.